### PR TITLE
Add swift support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       with:
-        artifacts: "treereduce-c,treereduce-java,treereduce-javascript,treereduce-lua,treereduce-rust,treereduce-souffle"
+        artifacts: "treereduce-c,treereduce-java,treereduce-javascript,treereduce-lua,treereduce-rust,treereduce-souffle,treereduce-swift"
         artifactErrorsFailBuild: true
         body: "See [CHANGELOG.md](https://github.com/langston-barrett/treereduce/blob/main/doc/CHANGELOG.md)."
         draft: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-swift"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55ecb0372483057cb8f0f80c54d1cf76a3e301281d8db16d6c080e19395360f"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-traversal"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +675,15 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "tree-sitter-souffle",
+ "treereduce",
+]
+
+[[package]]
+name = "treereduce-swift"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "tree-sitter-swift",
  "treereduce",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/treereduce-lua",
     "crates/treereduce-rust",
     "crates/treereduce-souffle",
+    "crates/treereduce-swift",
 ]
 
 # https://nnethercote.github.io/perf-book/build-configuration.html

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ static:
 	  --bin treereduce-lua \
 	  --bin treereduce-rust \
 	  --bin treereduce-souffle \
+	  --bin treereduce-swift \
 	  --locked \
 	  --release \
 	  --target=x86_64-unknown-linux-musl

--- a/crates/treereduce-swift/Cargo.toml
+++ b/crates/treereduce-swift/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "treereduce-swift"
+description = "Fast, parallel, syntax-aware program reducer for Swift"
+version = "0.3.0"
+keywords = ["program-reducer", "minimization", "test-case-reduction", "swift"]
+edition = "2021"
+authors = ["Langston Barrett <langston.barrett@gmail.com>"]
+license = "MIT"
+readme = "../../README.md"
+homepage = "https://github.com/langston-barrett/treereduce"
+repository = "https://github.com/langston-barrett/treereduce"
+
+[dependencies]
+anyhow = "1.0"
+treereduce = { version = "0.3.0", path = "../treereduce", features = ["cli"] }
+tree-sitter-swift = "0.4.3"

--- a/crates/treereduce-swift/src/main.rs
+++ b/crates/treereduce-swift/src/main.rs
@@ -1,0 +1,11 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+fn main() -> Result<()> {
+  treereduce::cli::main(
+    tree_sitter_swift::language(),
+    tree_sitter_swift::NODE_TYPES,
+    HashMap::new(),
+  )
+}


### PR DESCRIPTION
Add basic support for Swift https://github.com/langston-barrett/treereduce/issues/13.

I've tested this and it seems to work. One problem is that it hangs on the latest revision after a few iterations https://github.com/langston-barrett/treereduce/issues/109. To work around this, I also have another branch based on an old revision https://github.com/ellishg/treereduce/tree/treereduce-swift, but I believe this is a different problem.